### PR TITLE
More helpful error messages

### DIFF
--- a/src/transformObjectExpressionIntoStyleSheetObject.js
+++ b/src/transformObjectExpressionIntoStyleSheetObject.js
@@ -62,7 +62,7 @@ function processProperty(key, value, result, context) {
 
     result[name] = -value.argument.value;
   } else {
-    assert(false, 'invalid value expression type');
+    assert(false, `unexpected ${value.type} at ${value.loc.start.line}:${value.loc.start.column}`);
   }
 }
 

--- a/src/transformStyleSheetObjectIntoSpecification.js
+++ b/src/transformStyleSheetObjectIntoSpecification.js
@@ -127,7 +127,7 @@ function processRule(rules, key, value) {
 }
 
 function initStyleSpec(styles, name) {
-  assert(isValidStyleName.test(name), 'style name is invalid');
+  assert(isValidStyleName.test(name), `style name is invalid: ${name}`);
 
   styles[name] = styles[name] || { rules: {}, selectors: {}, mediaQueries: {} };
   return styles[name];

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ describe('babel-plugin-css-in-js', () => {
 
     const hasClassNameWithRule = new RegExp(`\\.${className}\\s*\\{[^\\}]*?${rule}`);
 
-    assert(hasClassNameWithRule.test(css));
+    assert(hasClassNameWithRule.test(css), `No rule ${rule} found for ${className}`);
   }
 
   it('does nothing if no "cssInJS" call is present', () => {

--- a/test/transformObjectExpressionIntoStyleSheetObject.js
+++ b/test/transformObjectExpressionIntoStyleSheetObject.js
@@ -92,11 +92,11 @@ describe('transformObjectExpressionIntoStyleSheetObject', () => {
     testInvalidInput('{ foo: { bar: "" } }',    /string value cannot be blank/);
     testInvalidInput('{ foo: { bar: "  " } }',  /string value cannot be blank/);
 
-    testInvalidInput('{ foo: { bar: [] } }',              /invalid value expression type/);
-    testInvalidInput('{ foo: { bar: Math.PI } }',         /invalid value expression type/);
-    testInvalidInput('{ foo: { bar: undefined } }',       /invalid value expression type/);
-    testInvalidInput('{ foo: { bar: missing + "bam" } }', /invalid value expression type/);
-    testInvalidInput('{ foo: { bar: baz[0] } }',          /invalid value expression type/);
+    testInvalidInput('{ foo: { bar: [] } }',              /unexpected/);
+    testInvalidInput('{ foo: { bar: Math.PI } }',         /unexpected/);
+    testInvalidInput('{ foo: { bar: undefined } }',       /unexpected/);
+    testInvalidInput('{ foo: { bar: missing + "bam" } }', /unexpected/);
+    testInvalidInput('{ foo: { bar: baz[0] } }',          /unexpected/);
 
     testInvalidInput('{ [null]: {} }',  /key must be a string or identifier/);
     testInvalidInput('{ [123]: {} }',   /key must be a string or identifier/);


### PR DESCRIPTION
Many error messages don’t provide any useful information about the source of the error. This fixes a few of the most common ones.