### PR TITLE
Support global selectors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,9 @@ function visitor(context) {
       const gcnOptions = extend({}, this.cssInJS.options, { prefixes: [this.cssInJS.filename, sheetId] });
 
       const properties = Object.keys(sheet).reduce((memo, styleId) => {
+        if (styleId.charAt(0) === '$') {
+          return memo;
+        }
         return memo.concat(
           t.objectProperty(
             t.identifier(styleId),

--- a/src/transformSpecificationIntoCSS.js
+++ b/src/transformSpecificationIntoCSS.js
@@ -21,7 +21,8 @@ function processStyle(css, name, spec, level, options) {
 function processRules(css, name, rules, level, options) {
   if (isEmpty(rules)) { return; }
 
-  css.push(indent(level) + '.' + generateClassName(name, options) + ' {');
+  const selector = name.charAt(0) === '$' ? name.substring(1) : ('.' + generateClassName(name, options));
+  css.push(indent(level) + selector + ' {');
 
   foreach(rules, (value, key) => {
     css.push(indent(level + 1) + buildCSSRule(key, value));

--- a/src/transformStyleSheetObjectIntoSpecification.js
+++ b/src/transformStyleSheetObjectIntoSpecification.js
@@ -5,7 +5,7 @@ import splitSelector from './utils/splitSelector';
 const isMediaQueryDeclaration = /^@/;
 const hasAttachedSelector = /[^:\[]+[:\[]/;
 const isStandaloneSelector = /^[:\[]/;
-const isValidStyleName = /^[_a-zA-Z]+[ _a-zA-Z0-9-]*[_a-zA-Z0-9-]*$/;
+const isValidStyleName = /^([_a-zA-Z]+[ _a-zA-Z0-9-]*[_a-zA-Z0-9-]*)|(\$[_a-zA-Z0-9-\s,\.]+)$/;
 
 export default function transformStyleSheetObjectIntoSpecification(content) {
   assertPlainObject(content);

--- a/test/transformSpecificationIntoCSS.js
+++ b/test/transformSpecificationIntoCSS.js
@@ -269,4 +269,30 @@ describe('transformSpecificationIntoCSS', () => {
       }
     `);
   });
+
+  it('supports global selectors', () => {
+    testCSS({
+      '$.foo': {
+        rules: {
+          fontFamily: 'Arial,Verdana,"Helvetica Neue",sans-serif',
+          margin: 10,
+          padding: '0 20px'
+        }
+      },
+      '$body': {
+        rules: {
+          border: 'solid 1px black'
+        }
+      }
+    }, css`
+      .foo {
+        font-family: Arial,Verdana,"Helvetica Neue",sans-serif;
+        margin: 10px;
+        padding: 0 20px;
+      }
+      body {
+        border: solid 1px black;
+      }
+    `);
+  });
 });

--- a/test/transformStyleSheetObjectIntoSpecification.js
+++ b/test/transformStyleSheetObjectIntoSpecification.js
@@ -737,6 +737,23 @@ describe('transformStyleSheetObjectIntoSpecification', () => {
         mediaQueries: {},
       }
     });
+
+
+    testValidInput({
+      '$  html,  body ': {
+        width: 150,
+        margin: 'auto'
+      }
+    }, {
+      '$  html,  body ': {
+        rules: {
+          width: 150,
+          margin: 'auto'
+        },
+        selectors: {},
+        mediaQueries: {},
+      }
+    });
   });
 
   it('throws on invalid input', () => {


### PR DESCRIPTION
This is an easy solution for #16. Any selector prefixed with `$` is passed through to the generated CSS unchanged, and omitted in the resulting JS object.

This allows for comma-separated lists of selectors as well, such as `{ '$html, body, .button': {} }`, which is pretty useful when defining global stylesheets.

An alternative solution would be to allow comma separated selectors everywhere, and requiring the prefixing of every selector individually (`{ foo: {}, bar: {}, '$html, $body, $.button, foo, bar': {} }`), but that would be a bigger change. Would love to hear thoughts on this.