### PR TITLE
add failing test case for nested selector

### DIFF
--- a/test/transformSpecificationIntoCSS.js
+++ b/test/transformSpecificationIntoCSS.js
@@ -283,7 +283,13 @@ describe('transformSpecificationIntoCSS', () => {
         rules: {
           border: 'solid 1px black'
         }
-      }
+      },
+      '.bar': {
+        parent: '.foo',
+        rules: {
+          color: 'red'
+        }
+      },
     }, css`
       .foo {
         font-family: Arial,Verdana,"Helvetica Neue",sans-serif;
@@ -292,6 +298,9 @@ describe('transformSpecificationIntoCSS', () => {
       }
       body {
         border: solid 1px black;
+      }
+      .foo .bar {
+        color: red;
       }
     `);
   });

--- a/test/transformStyleSheetObjectIntoSpecification.js
+++ b/test/transformStyleSheetObjectIntoSpecification.js
@@ -754,7 +754,28 @@ describe('transformStyleSheetObjectIntoSpecification', () => {
         mediaQueries: {},
       }
     });
+
+
+    testValidInput({
+      '$.foo': {
+        bar: {
+          color: 'red',
+          padding: 10
+        },
+      },
+    }, {
+      bar: {
+        parent: '.foo',
+        rules: {
+          width: 150,
+          margin: 'auto'
+        },
+        selectors: {},
+        mediaQueries: {},
+      }
+    });
   });
+
 
   it('throws on invalid input', () => {
     testInvalidInput("foo",     /value must be a plain object/);


### PR DESCRIPTION
hello

I open a PR to discuss the support of nested selector (issue #24)
I propose to handle global nesting using a parent prop in the specification object that is generated

Another way to support that is to it like in sass, using `&` char 
``` js
cssInJS({
  foo: {
    '& .bar': {
      color: 'red'
    },
    '.bar &': {
      color: 'green'
    }
  }
})   
```
should generate 
```css
.foo .bar {
  color: red;
}
.bar .foo {
  color: green;
}
```
what do you prefer ? and given i'm pretty new to babel-plugin, is there a simpler solution ?